### PR TITLE
Eliminado el uso de Lombok en el modelo de Student

### DIFF
--- a/src/main/java/com/example/demo/model/Student.java
+++ b/src/main/java/com/example/demo/model/Student.java
@@ -1,12 +1,10 @@
 package com.example.demo.model;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 
 @Data // con esto se hacen los getter y los setter
 @Getter
-@AllArgsConstructor
 public class Student {
 	private Integer id;
 	private String nombre;


### PR DESCRIPTION
Se usaba Lombok para crear un constructor de Student con todos sus atributos, pero al añadir otro constructor explícito con todos los atributos se crea un conflicto. Este commit elimina el uso de Lombok en Student