### PR TITLE
Eliminado el uso de la anotación "@AllArgsConstructor" de Lombok

### DIFF
--- a/src/main/java/com/example/demo/model/Student.java
+++ b/src/main/java/com/example/demo/model/Student.java
@@ -1,12 +1,10 @@
 package com.example.demo.model;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 
 @Data // con esto se hacen los getter y los setter
 @Getter
-@AllArgsConstructor
 public class Student {
 	private Integer id;
 	private String nombre;


### PR DESCRIPTION
Eliminado el uso de la anotación "@AllArgsConstructor" de Lombok ya que provocaba un conflicto con el constructor explícito de Student